### PR TITLE
[hotfix] - config file bug

### DIFF
--- a/src/Aws/Laravel/AwsServiceProvider.php
+++ b/src/Aws/Laravel/AwsServiceProvider.php
@@ -35,7 +35,7 @@ class AwsServiceProvider extends ServiceProvider
     {
         $this->app['aws'] = $this->app->share(function ($app) {
             // Instantiate the AWS service builder
-            $config = (isset($app['config']) && isset($app['config']['aws'])) ? $app['config']['aws'] : array();
+            $config = !empty($app['config']['aws']) ? $app['config']['aws'] : array();
             $aws = Aws::factory($config);
 
             // Attach an event listener that will append the Laravel version number in the user agent string

--- a/tests/Aws/Laravel/Tests/AwsServiceProviderTest.php
+++ b/tests/Aws/Laravel/Tests/AwsServiceProviderTest.php
@@ -64,6 +64,7 @@ class AwsServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         // Setup the Laravel app and AWS service provider
         $app = new Application();
+		$app['config'] = array();
         $provider = new AwsServiceProvider($app);
         $app->register($provider);
         $provider->boot();


### PR DESCRIPTION
`isset($app['config'])` check doesn't return `true` so `aws.php` config file never inject to `Aws::factory()`. Using `empty()` method is enough.
