### PR TITLE
AWS Facade Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Find the `providers` key in `app/config/app.php` and register the AWS Service Pr
     )
 ```
 
+Find the `aliases` key in `app/config/app.php` and add the AWS Facade alias.
+
+```php
+    'aliases' => array(
+        // ...
+        'AWS' => 'Aws\Laravel\AwsFacade',
+    )
+```
+
+
 ### 2. Manual Instantiation
 
 You can also register the provider and configuration options at runtime. This could be done in your global bootstrapping
@@ -86,6 +96,18 @@ Container](http://four.laravel.com/docs/ioc). The following example uses the Ama
 
 ```php
 $s3 = App::make('aws')->get('s3');
+$s3->putObject(array(
+    'Bucket'     => '<your-bucket>',
+    'Key'        => '<the-name-of-your-object>',
+    'SourceFile' => '/path/to/the/file/you/are/uploading.ext',
+));
+```
+
+If the AWS Facade is registered within the `aliases` section of the application configuration, you can use
+the following more expressive method.
+
+```php
+$s3 = AWS::get('s3');
 $s3->putObject(array(
     'Bucket'     => '<your-bucket>',
     'Key'        => '<the-name-of-your-object>',

--- a/src/Aws/Laravel/AwsFacade.php
+++ b/src/Aws/Laravel/AwsFacade.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Aws\Laravel;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * AWS SDK for PHP service provider for Laravel applications
+ */
+class AwsFacade extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor() { return 'aws'; }
+}

--- a/tests/Aws/Laravel/Tests/AwsFacadeTest.php
+++ b/tests/Aws/Laravel/Tests/AwsFacadeTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Aws\Laravel\Tests;
+
+use Aws\Laravel\AwsFacade as AWS;
+use Aws\Laravel\AwsServiceProvider;
+use Illuminate\Foundation\Application;
+
+/**
+ * AwsFacade test cases
+ */
+class AwsFacadeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFacadeCanBeResolvedToServiceInstance()
+    {
+        // Setup the Laravel app and AWS service provider
+        $app = new Application();
+        $provider = new AwsServiceProvider($app);
+        $app->register($provider, array(
+            'config' => array(
+                'aws' => array(
+                    'key'    => 'your-aws-access-key-id',
+                    'secret' => 'your-aws-secret-access-key',
+                ),
+            ),
+        ));
+        $provider->boot();
+
+        AWS::setFacadeApplication($app);
+
+        // Get an instance of a client (S3) to use for testing
+        /** @var $s3 \Aws\S3\S3Client */
+        $s3 = AWS::get('s3');
+        $this->assertInstanceOf('Aws\S3\S3Client', $s3);
+    }
+}


### PR DESCRIPTION
Hi guys,

Laravel team member here offering an AWS Facade to bring usage of the SDK more inline with Laravel's beautiful syntax. A simple change, but may seem more familiar to users of the framework.

``` php
$s3 = AWS::get('s3');
```

Test is included, and the README has been updated accordingly.

Thanks for the Laravel specific package, and all the great AWS services!

Dayle.
