### PR TITLE
Update aws-sdk-php version to 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "aws/aws-sdk-php": "~2.2",
+        "aws/aws-sdk-php": "~2.4",
         "illuminate/foundation": "4.*",
         "illuminate/support": "4.*"
     },


### PR DESCRIPTION
Much needed features were added to 2.4 including the most important IMO 'Added an easy to way to delete objects from an Amazon S3 bucket that match a regular expression or key prefix'
