### PR TITLE
Remove the beta tag from the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The AWS Service Provider can be installed via [Composer](http://getcomposer.org)
 ```json
 {
     "require": {
-        "aws/aws-sdk-php-laravel": "~2.0@beta"
+        "aws/aws-sdk-php-laravel": "~2.0"
     }
 }
 ```


### PR DESCRIPTION
Thanks so much for tagging a release for Laravel 5. Thought it might be best to take the `beta` out of the installation instructions.