### PR TITLE
Removed illuminate/foundation as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=5.3.3",
         "aws/aws-sdk-php": "~2.2",
-        "illuminate/foundation": "4.*",
-        "illuminate/support": "4.*"
+        "illuminate/support": "4.*",
+        "laravel/framework": "4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require": {
         "php": ">=5.3.3",
         "aws/aws-sdk-php": "~2.2",
-        "illuminate/support": "4.*",
-        "laravel/framework": "4.*"
+        "illuminate/support": "4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
I have found out today that illuminate/foundation has been abandoned. 
I propose a workaround that imports the entire framework, this provides the same foundation code that illuminate/foundation had. This is to ensure that anyone who still uses laravel 4.* will be able to deploy this package to their projects.