### PR TITLE
remove credentials if blank, causing the SDK to use ec2 role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ php:
 sudo: false
 
 matrix:
-	allow_failures:
-	  - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 install: travis_retry composer install --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
 
 sudo: false
 
+matrix:
+	allow_failures:
+	  - php: hhvm
+
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit

--- a/config/aws.php
+++ b/config/aws.php
@@ -16,10 +16,7 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-    'credentials' => [
-        'key'    => env('AWS_ACCESS_KEY_ID'),
-        'secret' => env('AWS_SECRET_ACCESS_KEY'),
-    ],
+
     'region' => env('AWS_REGION', 'us-east-1'),
     'version' => 'latest',
     'ua_append' => [

--- a/src/AwsServiceProvider.php
+++ b/src/AwsServiceProvider.php
@@ -41,7 +41,12 @@ class AwsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('aws', function ($app) {
-            return new Sdk($app['config']->get('aws'));
+			$config = $app['config']->get('aws');
+			if ( is_null ( $app['config']->get('aws')['credentials']['key'] ) && is_null( $app['config']->get('aws')['credentials']['secret'] ) )
+			{
+				unset( $config['credentials'] );
+			}
+            return new Sdk($config);
         });
 
         $this->app->alias('aws', 'Aws\Sdk');

--- a/src/AwsServiceProvider.php
+++ b/src/AwsServiceProvider.php
@@ -41,11 +41,10 @@ class AwsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('aws', function ($app) {
-			$config = $app['config']->get('aws');
-			if ( is_null ( $app['config']->get('aws')['credentials']['key'] ) && is_null( $app['config']->get('aws')['credentials']['secret'] ) )
-			{
-				unset( $config['credentials'] );
-			}
+            $config = $app['config']->get('aws');
+            if (is_null($app['config']->get('aws')['credentials']['key']) && is_null($app['config']->get('aws')['credentials']['secret'])) {
+                unset($config['credentials']);
+            }
             return new Sdk($config);
         });
 

--- a/src/AwsServiceProvider.php
+++ b/src/AwsServiceProvider.php
@@ -42,9 +42,6 @@ class AwsServiceProvider extends ServiceProvider
     {
         $this->app->singleton('aws', function ($app) {
             $config = $app['config']->get('aws');
-            if (is_null($app['config']->get('aws')['credentials']['key']) && is_null($app['config']->get('aws')['credentials']['secret'])) {
-                unset($config['credentials']);
-            }
             return new Sdk($config);
         });
 


### PR DESCRIPTION
This allows the AWS-SDK to connect if run on an ec2 instance without a key/secret needing to be provided.