### PR TITLE
Update illuminate constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.5.9",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/support": "~5.1"
+        "illuminate/support": "5.1.* || 5.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0"


### PR DESCRIPTION
Since Laravel [doesn't follow semantic versioning](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) we wont know if this package will break in version 5.3. The solution is to be more specific with the version constraint.