### PR TITLE
[Doc-only]Add documentation for credential option when upgrade larval 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ return [
 ];
 ```
 
+Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config 
+file instead of environment variable option if using php artisan `config:cache`.
+
 Learn more about [configuring the SDK](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html) on
 the SDK's User Guide.
 


### PR DESCRIPTION
In laravel [upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0) for 5.2.0 
> If you are using the config:cache command during deployment, you must make sure that you are only calling the env function from within your configuration files, and not from anywhere else in your application.

Adding more documentation about this behavior because in SDK credential chain, environment variable comes before config file option.

Addressing issue #101 

cc: @xibz 