### PR TITLE
Expose native AWS DynamoDb session handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.0 - 2017-05-17
+
+* Added DynamoDb session driver support.
+
 ## 3.1.0 - 2016-01-17
 
 * Added support for Lumen.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # AWS Service Provider for Laravel 5
 
-[![@awsforphp on Twitter](http://img.shields.io/badge/twitter-%40awsforphp-blue.svg?style=flat)](https://twitter.com/awsforphp) [![Build Status](https://img.shields.io/travis/aws/aws-sdk-php-laravel.svg)](https://travis-ci.org/aws/aws-sdk-php-laravel) [![Latest Stable Version](https://img.shields.io/packagist/v/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel) [![Total Downloads](https://img.shields.io/packagist/dt/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel) [![Gitter](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/aws/aws-sdk-php)
+[![@awsforphp on Twitter](http://img.shields.io/badge/twitter-%40awsforphp-blue.svg?style=flat)](https://twitter.com/awsforphp)
+[![Build Status](https://img.shields.io/travis/aws/aws-sdk-php-laravel.svg)](https://travis-ci.org/aws/aws-sdk-php-laravel)
+[![Latest Stable Version](https://img.shields.io/packagist/v/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
+[![Total Downloads](https://img.shields.io/packagist/dt/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
+[![Gitter](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/aws/aws-sdk-php)
 
-This is a simple [Laravel](http://laravel.com/) service provider for making it easy to include the official [AWS SDK for PHP](https://github.com/aws/aws-sdk-php) in your Laravel and Lumen applications.
+This is a simple [Laravel](http://laravel.com/) service provider for making it easy to include the official
+[AWS SDK for PHP](https://github.com/aws/aws-sdk-php) in your Laravel and Lumen applications.
 
-This README is for version 3.x of the service provider, which is implemented to work with Version 3 of the AWS SDK for PHP and Laravel 5.1+.
+This README is for version 3.x of the service provider, which is implemented to work with Version 3 of the AWS SDK for
+PHP and Laravel 5.1.
 
 **Major Versions:**
 
@@ -92,9 +98,11 @@ return [
 ];
 ```
 
-Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config  file instead of environment variable option if using php artisan `config:cache`.
+Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config 
+file instead of environment variable option if using php artisan `config:cache`.
 
-Learn more about [configuring the SDK](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html) on the SDK's User Guide.
+Learn more about [configuring the SDK](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html) on
+the SDK's User Guide.
 
 ## Usage
 
@@ -110,7 +118,8 @@ $s3->putObject(array(
 ));
 ```
 
-If the AWS facade is registered within the `aliases` section of the application configuration, you can also use the following technique.
+If the AWS facade is registered within the `aliases` section of the application configuration, you can also use the
+following technique.
 
 ```php
 $s3 = AWS::createClient('s3');
@@ -123,19 +132,25 @@ $s3->putObject(array(
 
 ## `dynamodb` Session Driver
 
-This package publishes the [AWS DynamoDb session driver](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html) for use in Laravel. You must first [create a DynamoDb table for your PHP sessions](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#create-a-table-for-storing-your-sessions) and then configure your application.
+This package publishes the [AWS DynamoDb session driver](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html) 
+for use in Laravel. You must first [create a DynamoDb table for your PHP sessions](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#create-a-table-for-storing-your-sessions) 
+and then configure your application.
 
-Using the DynamoDb driver is exactly the same as any other [Laravel session driver](https://laravel.com/docs/5.4/session). Simply change your `driver` configuration option to `dynamodb` and add/update any of the following configuration options ([see AWS docs](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#configuration) for more information, and please note that `table` and `lifetime` have been renamed to be consistent with all other Laravel session drivers):
+Using the DynamoDb driver is exactly the same as any other [Laravel session driver](https://laravel.com/docs/5.4/session). 
+Simply change your `driver` configuration option to `dynamodb` and add/update any of the following configuration options 
+([see AWS docs](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#configuration) for 
+more information, and please note that `table` and `lifetime` have been renamed to be consistent with all other Laravel 
+session drivers):
 
-  - `table`: This should be the name of the DynamoDb table you created
-  - `hash_key`: Name of hash key in table (default is `id`)
-  - `lifetime`: Session lifetime
-  - `consistent_read`: Whether or not to use consistent reads
-  - `batch_config`: Batch options used for garbage collection
-  - `locking`: Whether or not to use session locking
-  - `max_lock_wait_time`: Max time (in seconds) to wait for lock acquisition
-  - `min_lock_retry_microtime`: Min time (in µs) to wait between lock attempts
-  - `max_lock_retry_microtime`: Max time (in µs) to wait between lock attempts
+* `table`: This should be the name of the DynamoDb table you created
+* `hash_key`: Name of hash key in table (default is `id`)
+* `lifetime`: Session lifetime
+* `consistent_read`: Whether or not to use consistent reads
+* `batch_config`: Batch options used for garbage collection
+* `locking`: Whether or not to use session locking
+* `max_lock_wait_time`: Max time (in seconds) to wait for lock acquisition
+* `min_lock_retry_microtime`: Min time (in µs) to wait between lock attempts
+* `max_lock_retry_microtime`: Max time (in µs) to wait between lock attempts
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # AWS Service Provider for Laravel 5
 
-[![@awsforphp on Twitter](http://img.shields.io/badge/twitter-%40awsforphp-blue.svg?style=flat)](https://twitter.com/awsforphp)
-[![Build Status](https://img.shields.io/travis/aws/aws-sdk-php-laravel.svg)](https://travis-ci.org/aws/aws-sdk-php-laravel)
-[![Latest Stable Version](https://img.shields.io/packagist/v/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
-[![Total Downloads](https://img.shields.io/packagist/dt/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/aws/aws-sdk-php?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![@awsforphp on Twitter](http://img.shields.io/badge/twitter-%40awsforphp-blue.svg?style=flat)](https://twitter.com/awsforphp) [![Build Status](https://img.shields.io/travis/aws/aws-sdk-php-laravel.svg)](https://travis-ci.org/aws/aws-sdk-php-laravel) [![Latest Stable Version](https://img.shields.io/packagist/v/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel) [![Total Downloads](https://img.shields.io/packagist/dt/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel) [![Gitter](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/aws/aws-sdk-php)
 
-This is a simple [Laravel](http://laravel.com/) service provider for making it easy to include the official
-[AWS SDK for PHP](https://github.com/aws/aws-sdk-php) in your Laravel and Lumen applications.
+This is a simple [Laravel](http://laravel.com/) service provider for making it easy to include the official [AWS SDK for PHP](https://github.com/aws/aws-sdk-php) in your Laravel and Lumen applications.
 
-This README is for version 3.x of the service provider, which is implemented to work with Version 3 of the AWS SDK for
-PHP and Laravel 5.1.
+This README is for version 3.x of the service provider, which is implemented to work with Version 3 of the AWS SDK for PHP and Laravel 5.1+.
 
 **Major Versions:**
 
@@ -98,11 +92,9 @@ return [
 ];
 ```
 
-Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config 
-file instead of environment variable option if using php artisan `config:cache`.
+Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config  file instead of environment variable option if using php artisan `config:cache`.
 
-Learn more about [configuring the SDK](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html) on
-the SDK's User Guide.
+Learn more about [configuring the SDK](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html) on the SDK's User Guide.
 
 ## Usage
 
@@ -118,8 +110,7 @@ $s3->putObject(array(
 ));
 ```
 
-If the AWS facade is registered within the `aliases` section of the application configuration, you can also use the
-following technique.
+If the AWS facade is registered within the `aliases` section of the application configuration, you can also use the following technique.
 
 ```php
 $s3 = AWS::createClient('s3');
@@ -130,10 +121,27 @@ $s3->putObject(array(
 ));
 ```
 
+## `dynamodb` Session Driver
+
+This package publishes the [AWS DynamoDb session driver](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html) for use in Laravel. You must first [create a DynamoDb table for your PHP sessions](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#create-a-table-for-storing-your-sessions) and then configure your application.
+
+Using the DynamoDb driver is exactly the same as any other [Laravel session driver](https://laravel.com/docs/5.4/session). Simply change your `driver` configuration option to `dynamodb` and add/update any of the following configuration options ([see AWS docs](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html#configuration) for more information, and please note that `table` and `lifetime` have been renamed to be consistent with all other Laravel session drivers):
+
+  - `table`: This should be the name of the DynamoDb table you created
+  - `hash_key`: Name of hash key in table (default is `id`)
+  - `lifetime`: Session lifetime
+  - `consistent_read`: Whether or not to use consistent reads
+  - `batch_config`: Batch options used for garbage collection
+  - `locking`: Whether or not to use session locking
+  - `max_lock_wait_time`: Max time (in seconds) to wait for lock acquisition
+  - `min_lock_retry_microtime`: Min time (in µs) to wait between lock attempts
+  - `max_lock_retry_microtime`: Max time (in µs) to wait between lock attempts
+
 ## Links
 
 * [AWS SDK for PHP on Github](http://github.com/aws/aws-sdk-php/)
 * [AWS SDK for PHP website](http://aws.amazon.com/sdkforphp/)
 * [AWS on Packagist](https://packagist.org/packages/aws/)
+* [DynamoDb Session Handler](https://docs.aws.amazon.com/aws-sdk-php/v2/guide/feature-dynamodb-session-handler.html)
 * [License](http://aws.amazon.com/apache2.0/)
 * [Laravel website](http://laravel.com/)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
         "illuminate/support": "~5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "~4.0|~5.0",
+        "mockery/mockery": "^0.9.9",
+        "laravel/framework": "^5.4",
+        "laravel/lumen-framework": "^5.4"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0",
         "mockery/mockery": "^0.9.9",
-        "laravel/framework": "^5.4",
-        "laravel/lumen-framework": "^5.4"
+        "laravel/framework": "~5.1",
+        "laravel/lumen-framework": "~5.1"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0",
-        "mockery/mockery": "^0.9.9",
-        "laravel/framework": "~5.1",
-        "laravel/lumen-framework": "~5.1"
+        "mockery/mockery": "^0.9.9"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/src/AwsServiceProvider.php
+++ b/src/AwsServiceProvider.php
@@ -1,8 +1,11 @@
 <?php namespace Aws\Laravel;
 
 use Aws\Sdk;
+use Aws\DynamoDb\SessionHandler;
 use Illuminate\Foundation\Application as LaravelApplication;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Session;
 use Laravel\Lumen\Application as LumenApplication;
 
 /**
@@ -10,14 +13,7 @@ use Laravel\Lumen\Application as LumenApplication;
  */
 class AwsServiceProvider extends ServiceProvider
 {
-    const VERSION = '3.1.0';
-
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
+    const VERSION = '3.2.0';
 
     /**
      * Bootstrap the configuration
@@ -35,6 +31,22 @@ class AwsServiceProvider extends ServiceProvider
         }
 
         $this->mergeConfigFrom($source, 'aws');
+
+        Session::extend('dynamodb', function ($app) {
+            $client = $app->make('aws')->createClient('DynamoDb');
+            $config = $app->make('config')->get('session');
+            return SessionHandler::fromClient($client, array_filter([
+                'table_name' => Arr::get($config, 'table'),
+                'hash_key' => Arr::get($config, 'hash_key'),
+                'session_lifetime' => Arr::get($config, 'lifetime'),
+                'consistent_read' => Arr::get($config, 'consistent_read'),
+                'batch_config' => Arr::get($config, 'batch_config'),
+                'locking' => Arr::get($config, 'locking'),
+                'max_lock_wait_time' => Arr::get($config, 'max_lock_wait_time'),
+                'min_lock_retry_microtime' => Arr::get($config, 'min_lock_retry_microtime'),
+                'max_lock_retry_microtime' => Arr::get($config, 'max_lock_retry_microtime'),
+            ]));
+        });
     }
 
     /**

--- a/src/AwsServiceProvider.php
+++ b/src/AwsServiceProvider.php
@@ -5,7 +5,6 @@ use Aws\DynamoDb\SessionHandler;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\Session;
 use Laravel\Lumen\Application as LumenApplication;
 
 /**
@@ -32,21 +31,23 @@ class AwsServiceProvider extends ServiceProvider
 
         $this->mergeConfigFrom($source, 'aws');
 
-        Session::extend('dynamodb', function ($app) {
-            $client = $app->make('aws')->createClient('DynamoDb');
-            $config = $app->make('config')->get('session');
-            return SessionHandler::fromClient($client, array_filter([
-                'table_name' => Arr::get($config, 'table'),
-                'hash_key' => Arr::get($config, 'hash_key'),
-                'session_lifetime' => Arr::get($config, 'lifetime'),
-                'consistent_read' => Arr::get($config, 'consistent_read'),
-                'batch_config' => Arr::get($config, 'batch_config'),
-                'locking' => Arr::get($config, 'locking'),
-                'max_lock_wait_time' => Arr::get($config, 'max_lock_wait_time'),
-                'min_lock_retry_microtime' => Arr::get($config, 'min_lock_retry_microtime'),
-                'max_lock_retry_microtime' => Arr::get($config, 'max_lock_retry_microtime'),
-            ]));
-        });
+        if ($this->app->bound('session')) {
+            $this->app->make('session')->extend('dynamodb', function ($app) {
+                $client = $app->make('aws')->createClient('DynamoDb');
+                $config = $app->make('config')->get('session');
+                return SessionHandler::fromClient($client, array_filter([
+                    'table_name' => Arr::get($config, 'table'),
+                    'hash_key' => Arr::get($config, 'hash_key'),
+                    'session_lifetime' => Arr::get($config, 'lifetime'),
+                    'consistent_read' => Arr::get($config, 'consistent_read'),
+                    'batch_config' => Arr::get($config, 'batch_config'),
+                    'locking' => Arr::get($config, 'locking'),
+                    'max_lock_wait_time' => Arr::get($config, 'max_lock_wait_time'),
+                    'min_lock_retry_microtime' => Arr::get($config, 'min_lock_retry_microtime'),
+                    'max_lock_retry_microtime' => Arr::get($config, 'max_lock_retry_microtime'),
+                ]));
+            });
+        }
     }
 
     /**

--- a/tests/AwsServiceProviderTest.php
+++ b/tests/AwsServiceProviderTest.php
@@ -69,7 +69,7 @@ abstract class AwsServiceProviderTest extends \PHPUnit_Framework_TestCase
      *
      * @return AwsServiceProvider
      */
-    private function setupServiceProvider(Container $app)
+    protected function setupServiceProvider(Container $app)
     {
         // Create and register the provider.
         $provider = new AwsServiceProvider($app);

--- a/tests/LaravelAwsServiceProviderTest.php
+++ b/tests/LaravelAwsServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Config\Repository;
 use Illuminate\Foundation\Application;
+use \Mockery as M;
 
 class LaravelAwsServiceProviderTest extends AwsServiceProviderTest
 {
@@ -22,5 +23,18 @@ class LaravelAwsServiceProviderTest extends AwsServiceProviderTest
         $app->instance('config', new Repository());
 
         return $app;
+    }
+
+    public function testSessionDriverIsRegistered()
+    {
+        $app = $this->setupApplication();
+
+        $session = M::mock(StdClass::class);
+        $session->shouldReceive('extend')->with('dynamodb', \Closure::class)->once();
+        $app->instance('session', $session);
+
+        $this->setupServiceProvider($app);
+
+        M::close();
     }
 }

--- a/tests/LaravelAwsServiceProviderTest.php
+++ b/tests/LaravelAwsServiceProviderTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Config\Repository;
 use Illuminate\Foundation\Application;
-use \Mockery as M;
+use Mockery as M;
 
 class LaravelAwsServiceProviderTest extends AwsServiceProviderTest
 {

--- a/tests/LumenAwsServiceProviderTest.php
+++ b/tests/LumenAwsServiceProviderTest.php
@@ -3,6 +3,7 @@ namespace Aws\Laravel\Test;
 
 use Illuminate\Config\Repository;
 use Laravel\Lumen\Application;
+use Mockery as M;
 
 class LumenAwsServiceProviderTest extends AwsServiceProviderTest
 {
@@ -22,5 +23,14 @@ class LumenAwsServiceProviderTest extends AwsServiceProviderTest
         $app->instance('config', new Repository());
 
         return $app;
+    }
+
+    public function testSessionDriverIsNotRegistered()
+    {
+        $app = $this->setupApplication();
+        $app->resolving('session', function() {
+            $this->fail('Should not resolve session when boot() is called in Lumen context.');
+        });
+        $this->setupServiceProvider($app);
     }
 }


### PR DESCRIPTION
**NOTE: This feature needs more testing before it can be merged.**

I'm submitting it now to get feedback from others. It should theoretically work, but it needs to be tested in an actual AWS environment with various options. I will do that soon, but I wanted to submit the initial PR now so that others could take a look and perhaps do some testing with their own setup.

See the updates to the `README.md` file for information about this change.  Essentially, it just registers a `dynamodb` session driver, and handles some very minimal transformation on config options (so that the stock Laravel options work out of the box).

Because Laravel uses PHP's built in `\SessionHandlerInterface` and the AWS SDK's provided `Aws\DynamoDb\SessionHandler` class implements that interface, there's really not much that needs to be done for the integration. It's mostly just registering the driver and pulling options from the default `config/session.php` file.

The only side effect of this change is that the Service Provider can no longer be deferred because it needs to register the driver on `boot()`.