### PR TITLE
added --provider option for vendor:publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ AWS_REGION (default = us-east-1)
 To customize the configuration file, publish the package configuration using Artisan.
 
 ```sh
-php artisan vendor:publish
+php artisan vendor:publish  --provider="Aws\Laravel\AwsServiceProvider"
 ```
 
 Update your settings in the generated `app/config/aws.php` configuration file.


### PR DESCRIPTION
It prevents you from accidentally publishing resources from other service providers (if any)