### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/support": "~5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "~4.8.35|~5.4.3"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/tests/AwsServiceProviderTest.php
+++ b/tests/AwsServiceProviderTest.php
@@ -3,8 +3,9 @@
 use Aws\Laravel\AwsFacade as AWS;
 use Aws\Laravel\AwsServiceProvider;
 use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
 
-abstract class AwsServiceProviderTest extends \PHPUnit_Framework_TestCase
+abstract class AwsServiceProviderTest extends TestCase
 {
 
     public function testFacadeCanBeResolvedToServiceInstance()


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`~5.4.3`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#543---2016-06-09), that support this namespace.