### PR TITLE
Added credentials to config file with preference for .env file

### DIFF
--- a/config/aws.php
+++ b/config/aws.php
@@ -16,7 +16,10 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-
+    'credentials' => [
+        'key'    => env('AWS_ACCESS_KEY_ID', ''),
+        'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
+    ],
     'region' => env('AWS_REGION', 'us-east-1'),
     'version' => 'latest',
     'ua_append' => [


### PR DESCRIPTION
This change adds the AWS credentials parameters to the config file by default, with a preference towards using the `.env` file. This is more idiomatic of the Laravel framework, but users still have the option to delete this section to use the [standard SDK credential provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html). 