### PR TITLE
Config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ To customize the configuration file, publish the package configuration using Art
 php artisan vendor:publish  --provider="Aws\Laravel\AwsServiceProvider"
 ```
 
-Update your settings in the generated `config/aws.php` configuration file.
+The settings can be found in the generated `config/aws.php` configuration file. By default, the credentials and region settings will pull from your `.env` file.
 
 ```php
 return [
     'credentials' => [
-        'key'    => 'YOUR_AWS_ACCESS_KEY_ID',
-        'secret' => 'YOUR_AWS_SECRET_ACCESS_KEY',
+        'key'    => env('AWS_ACCESS_KEY_ID', ''),
+        'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
     ],
-    'region' => 'us-west-2',
+    'region' => env('AWS_REGION', 'us-east-1'),
     'version' => 'latest',
     
     // You can override settings for specific services

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ return [
 ];
 ```
 
+Note that you can always delete the `credentials` line from this file if you'd like to use the [default SDK Configuration Provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain) instead.
+
 Referring Laravel 5.2.0 [Upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0), you must using config 
 file instead of environment variable option if using php artisan `config:cache`.
 

--- a/config/aws.php
+++ b/config/aws.php
@@ -16,7 +16,10 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-
+    'credentials' => [
+        'key'    => env('AWS_ACCESS_KEY_ID', ''),
+        'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
+    ],
     'region' => env('AWS_REGION', 'us-east-1'),
     'version' => 'latest',
     'ua_append' => [


### PR DESCRIPTION
This change adds the AWS credentials parameters to the config file by default, with a preference towards using the `.env` file. This is more idiomatic of the Laravel framework, but users will still have the option to delete this section to use the [standard SDK credential provider chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html). This change will only affect new installations that publish the service provider - existing installations will not be affected.

Resolves #136 