### PR TITLE
Corrected dead link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ the SDK's User Guide.
 
 ## Usage
 
-In order to use the AWS SDK for PHP within your app, you need to retrieve it from the [Laravel IoC
-Container](http://laravel.com/docs/ioc). The following example uses the Amazon S3 client to upload a file.
+In order to use the AWS SDK for PHP within your app, you need to retrieve it from the [Laravel Service
+Container](https://laravel.com/docs/container#binding). The following example uses the Amazon S3 client to upload a file.
 
 ```php
 $s3 = App::make('aws')->createClient('s3');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Corrected a dead link to Laravel Service Containers in the README.

Laravel has changed IoC containers to just Service Containers in version ^5.0 of the framework. I've corrected the link to point to the correct documentation [here](https://laravel.com/docs/container#binding): 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
