### PR TITLE
Travis & Laravel 6 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - hhvm
   - nightly
 
@@ -16,6 +17,7 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: nightly
+    - php: 7.4
 
 before_install:
 - echo "memory_limit=3G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ remove-deps:
 
 uninstall-laravel: remove-deps
 	composer remove laravel/framework
+	composer remove illuminate/support
 
 uninstall-lumen: remove-deps
 	composer remove laravel/lumen-framework
+	composer remove illuminate/support
 
 # Ensures that the TAG variable was passed to the make command
 check-tag:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PHP and Laravel 5.1.
 
 **Major Versions:**
 
-* **3.x** (YOU ARE HERE) - For `laravel/framework:~5.1` and `aws/aws-sdk-php:~3.0`
+* **3.x** (YOU ARE HERE) - For `laravel/framework:~5.1|~6.0` and `aws/aws-sdk-php:~3.0`
 * **2.x** ([2.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/2.0)) - For `laravel/framework:5.0.*` and `aws/aws-sdk-php:~2.4`
 * **1.x** ([1.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/1.0)) - For `laravel/framework:4.*` and `aws/aws-sdk-php:~2.4`
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.5.9",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/support": "~5.1"
+        "illuminate/support": "~5.1|~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0",


### PR DESCRIPTION
* Adds ~6.0 to allowed versions for `illuminate/support`
* Modifies Makefile to resolve Lumen/Laravel dependency conflict for unit tests
* Switches travis builds to `trusty`, for PHP 5.5.x support
* Thanks to @djfrailey for the [initial PR](https://github.com/aws/aws-sdk-php-laravel/pull/169)

Resolves #168 