### PR TITLE
Fix labels applied to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us improve
 title: ''
-labels: needs-triage, bug report
+labels: needs-triage, bug
 assignees: ''
 
 ---


### PR DESCRIPTION
Issues from `Bug report` template had nonexistent `bug report` label applied instead of `bug`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
