### PR TITLE
Load AWS_REGION from laravel .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ return [
         'key'    => env('AWS_ACCESS_KEY_ID', ''),
         'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
     ],
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
     'version' => 'latest',
     
     // You can override settings for specific services

--- a/config/aws_default.php
+++ b/config/aws_default.php
@@ -17,7 +17,7 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,

--- a/config/aws_publish.php
+++ b/config/aws_publish.php
@@ -20,7 +20,7 @@ return [
         'key'    => env('AWS_ACCESS_KEY_ID', ''),
         'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
     ],
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,


### PR DESCRIPTION
Hi,

### Description of changes:
By default; Laravel loads the AWS Region value from `AWS_DEFAULT_REGION` environment variable

https://github.com/laravel/laravel/blob/3cdfe0ce952c0b202150855b2f846996ebd4ba4a/.env.example#L37

This patch will make this package to look for  `AWS_REGION` first and if not defined; it will fallback to `AWS_DEFAULT_REGION`.

This change is backward compatible and wont break existing installs.

--------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
