### PR TITLE
Laravel environment match

### DIFF
--- a/config/aws_default.php
+++ b/config/aws_default.php
@@ -17,7 +17,7 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,

--- a/config/aws_publish.php
+++ b/config/aws_publish.php
@@ -20,7 +20,7 @@ return [
         'key'    => env('AWS_ACCESS_KEY_ID', ''),
         'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
     ],
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => env('AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,


### PR DESCRIPTION
*Description of changes:*
Since Laravel 5.7 where they added the default environment variables for AWS to the .env.example the region variable has been called `AWS_DEFAULT_REGION`, however this package by default looks for `AWS_REGION` and then falls back to `us-east-1`.

This PR adjusts the confirm file to first look for `AWS_REGION` else `AWS_DEFAULT_REGION` else `us-east-1`.

This is a non-breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
