### PR TITLE
added support for Laravel 5.8+, no need to change env variable name now

### DIFF
--- a/config/aws_default.php
+++ b/config/aws_default.php
@@ -1,6 +1,14 @@
 <?php
 
 use Aws\Laravel\AwsServiceProvider;
+use Illuminate\Support\Facades\App;
+
+
+if (version_compare(App::version(), '5.8.0', '>=')) {
+    $awsRegion = env('AWS_DEFAULT_REGION', 'us-east-1');
+} else {
+    $awsRegion = env('AWS_REGION', 'us-east-1');
+}
 
 return [
 
@@ -17,7 +25,7 @@ return [
     | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html
     |
     */
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => $awsRegion,
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,

--- a/config/aws_publish.php
+++ b/config/aws_publish.php
@@ -1,6 +1,14 @@
 <?php
 
 use Aws\Laravel\AwsServiceProvider;
+use Illuminate\Support\Facades\App;
+
+
+if (version_compare(App::version(), '5.8.0', '>=')) {
+    $awsRegion = env('AWS_DEFAULT_REGION', 'us-east-1');
+} else {
+    $awsRegion = env('AWS_REGION', 'us-east-1');
+}
 
 return [
 
@@ -20,7 +28,7 @@ return [
         'key'    => env('AWS_ACCESS_KEY_ID', ''),
         'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
     ],
-    'region' => env('AWS_REGION', 'us-east-1'),
+    'region' => $awsRegion,
     'version' => 'latest',
     'ua_append' => [
         'L5MOD/' . AwsServiceProvider::VERSION,


### PR DESCRIPTION
*Issue :* #216 

*Description of changes:* From Laravel 5.8 the provided example .env variables for configuring AWS settings have been changed a bit, for configuring the default region Laravel is using the AWS_DEFAULT_REGION key which was AWS_REGION before Laravel 5.8. Added support for all the Laravel versions here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
