### PR TITLE
Add support for Laravel 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS Service Provider for Laravel 5/6/7/8/9/10
+# AWS Service Provider for Laravel 5 - 11
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
 [![Total Downloads](https://img.shields.io/packagist/dt/aws/aws-sdk-php-laravel.svg)](https://packagist.org/packages/aws/aws-sdk-php-laravel)
@@ -12,7 +12,7 @@ PHP and Laravel 5.1.
 
 **Major Versions:**
 
-* **3.x** (YOU ARE HERE) - For `laravel/framework:~5.1|~6.0|~7.0|~8.0|9.0|10.0` and `aws/aws-sdk-php:~3.0`
+* **3.x** (YOU ARE HERE) - For `laravel/framework:5.1|6.0|7.0|8.0|9.0|10.0|11.0` and `aws/aws-sdk-php:~3.0`
 * **2.x** ([2.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/2.0)) - For `laravel/framework:5.0.*` and `aws/aws-sdk-php:~2.4`
 * **1.x** ([1.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/1.0)) - For `laravel/framework:4.*` and `aws/aws-sdk-php:~2.4`
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "aws/aws-sdk-php-laravel",
     "homepage": "http://aws.amazon.com/sdkforphp2",
-    "description": "A simple Laravel 5/6/7/8/9 service provider for including the AWS SDK for PHP.",
-    "keywords": ["laravel", "laravel 5", "laravel 6", "laravel 7", "laravel 8", "laravel 9", "laravel 10", "aws", "amazon", "sdk", "s3", "ec2", "dynamodb"],
+    "description": "A simple Laravel v5.1 - v11 service provider for including the AWS SDK for PHP.",
+    "keywords": ["laravel", "laravel 5", "laravel 6", "laravel 7", "laravel 8", "laravel 9", "laravel 10", "laravel 11", "aws", "amazon", "sdk", "s3", "ec2", "dynamodb"],
     "type":"library",
     "license":"Apache-2.0",
     "authors":[
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.5.9",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+        "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^9.0",
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^9.0 || ^10.0",
         "vlucas/phpdotenv": "^1.0 || ^2.0 || ^3.0 || ^4.0 || ^5.0",
         "yoast/phpunit-polyfills": "^1.0"
     },


### PR DESCRIPTION
## Description

Laravel 11 is due to be released any day (it was scheduled for Feb 6). This will get ahead of the curve so this package supports Laravel 11 from day one.

I've incremented the version of Illuminate as well as PHPUnit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Question: should it be considered to modify the version constraints to `>=5.1`?