### PR TITLE
enhancement: deprecate versions below 7.2.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,19 +13,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-versions: '5.5'
-            laravel-versions: '5.1.*'
-          - php-versions: '5.6'
-            laravel-versions: '5.1.*'
-          - php-versions: '7.0'
-            laravel-versions: '5.5.*'
-          - php-versions: '7.1'
-            laravel-versions: '^5.5'
-          - php-versions: '7.2'
-            laravel-versions: '^5.5'
-          - php-versions: '7.2'
+          - php-versions: '7.2.5'
             laravel-versions: '^6.0'
-          - php-versions: '7.2'
+          - php-versions: '7.2.5'
             laravel-versions: '^7.0'
           - php-versions: '7.3'
             laravel-versions: '^6.0'
@@ -55,6 +45,16 @@ jobs:
             laravel-versions: '^9.0'
           - php-versions: '8.2'
             laravel-versions: '^10.0'
+          - php-versions: '8.2'
+            laravel-versions: '^11.0'
+          - php-versions: '8.3'
+            laravel-versions: '^9.0'
+          - php-versions: '8.3'
+            laravel-versions: '^10.0'
+          - php-versions: '8.3'
+            laravel-versions: '^9.0'
+          - php-versions: '8.3'
+            laravel-versions: '^11.0'
 
     #set the name for each job
     name: PHP ${{ matrix.php-versions }} with Laravel ${{ matrix.laravel-versions }}
@@ -91,8 +91,7 @@ jobs:
 
       #require lumen
       - name: Require lumen
-        if: ${{ matrix.laravel-versions != '^10.0' && (matrix.php-versions != '^8.0' && matrix.laravel-versions != '^7.0') }}
-        run: composer require laravel/lumen-framework:${{ matrix.laravel-versions }} --no-interaction --prefer-dist --no-plugins
+        run: composer require laravel/lumen-framework --no-interaction --prefer-dist --no-plugins
 
       #run tests
       - name: Run test suite

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PHP and Laravel 5.1.
 
 **Major Versions:**
 
-* **3.x** (YOU ARE HERE) - For `laravel/framework:5.1|6.0|7.0|8.0|9.0|10.0|11.0` and `aws/aws-sdk-php:~3.0`
+* **3.x** (YOU ARE HERE) - For `laravel/framework:6.0|7.0|8.0|9.0|10.0|11.0` and `aws/aws-sdk-php:^3.279.0`
 * **2.x** ([2.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/2.0)) - For `laravel/framework:5.0.*` and `aws/aws-sdk-php:~2.4`
 * **1.x** ([1.0 branch](https://github.com/aws/aws-sdk-php-laravel/tree/1.0)) - For `laravel/framework:4.*` and `aws/aws-sdk-php:~2.4`
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "aws/aws-sdk-php-laravel",
-    "homepage": "http://aws.amazon.com/sdkforphp2",
-    "description": "A simple Laravel v5.1 - v11 service provider for including the AWS SDK for PHP.",
-    "keywords": ["laravel", "laravel 5", "laravel 6", "laravel 7", "laravel 8", "laravel 9", "laravel 10", "laravel 11", "aws", "amazon", "sdk", "s3", "ec2", "dynamodb"],
+    "homepage": "https://aws.amazon.com/sdk-for-php/",
+    "description": "A simple Laravel 6/7/8/9/10/11 service provider for including the AWS SDK for PHP.",
+    "keywords": ["laravel", "laravel 6", "laravel 7", "laravel 8", "laravel 9", "laravel 10", "laravel 11", "aws", "amazon", "sdk", "s3", "ec2", "dynamodb"],
     "type":"library",
     "license":"Apache-2.0",
     "authors":[
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "aws/aws-sdk-php": "~3.0",
-        "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
+        "php": ">=7.2.5",
+        "aws/aws-sdk-php": "^3.279.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "vlucas/phpdotenv": "^1.0 || ^2.0 || ^3.0 || ^4.0 || ^5.0",
         "yoast/phpunit-polyfills": "^1.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
 
     <testsuites>
         <testsuite name="AwsServiceProvider Test Suite">
@@ -22,12 +21,13 @@
         <env name="AWS_REGION" value="baz"/>
     </php>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
+    <coverage>
+        <include>
             <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory suffix=".php">vendor</directory>
+        </exclude>
+    </coverage>
+
 </phpunit>


### PR DESCRIPTION
*Issue #, if available:*
closes #238 

*Description of changes:*
Deprecates PHP runtimes `<7.2.5`, adds test coverage for Laravel 11 and PHP 8.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
